### PR TITLE
Chore: error message on no store

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,1 +1,0 @@
-"""Parca Agent Operator Python Module."""

--- a/src/charm.py
+++ b/src/charm.py
@@ -5,7 +5,7 @@
 """Charmed Operator to deploy Parca Agent."""
 
 import logging
-from typing import Dict
+from typing import Dict, Optional
 
 import ops
 from charms.grafana_agent.v0.cos_agent import COSAgentProvider, charm_tracing_config
@@ -23,9 +23,9 @@ logger = logging.getLogger(__name__)
 @trace_charm(
     tracing_endpoint="charm_tracing_endpoint",
     extra_types=(
-        ParcaAgent,
-        COSAgentProvider,
-        ParcaStoreEndpointRequirer,
+            ParcaAgent,
+            COSAgentProvider,
+            ParcaStoreEndpointRequirer,
     ),
 )
 class ParcaAgentOperatorCharm(ops.CharmBase):
@@ -69,21 +69,10 @@ class ParcaAgentOperatorCharm(ops.CharmBase):
 
     # === STORE CONFIG === #
     @property
-    def _store_config(self) -> Dict[str, str]:
-        return self._store_requirer.config or self._default_store_config
-
-    @property
-    def _default_store_config(self) -> Dict[str, str]:
-        """Default remote store config as parca-agent defines them."""
-        return {
-            "remote-store-address": "grpc.polarsignals.com:443",
-            "remote-store-bearer-token": "",
-            # needs to be a lowercase string
-            "remote-store-insecure": "false",
-        }
+    def _store_config(self) -> Optional[Dict[str, str]]:
+        return self._store_requirer.config
 
     # === EVENT HANDLERS === #
-
     def _on_install(self, _):
         """Install dependencies for Parca Agent and ensure initial configs are written."""
         self.unit.status = ops.MaintenanceStatus("installing parca-agent")
@@ -112,30 +101,45 @@ class ParcaAgentOperatorCharm(ops.CharmBase):
 
     def _on_collect_unit_status(self, event: ops.CollectStatusEvent):
         """Set unit status depending on the state."""
-        if not self.parca_agent.installed:
+        if not self._store_config:
             event.add_status(
                 ops.BlockedStatus(
-                    "Failed to install parca-agent snap. Check `juju debug-log` for errors."
+                    "No store configured; relate with a `parca_store` provider to start "
+                    "sending profiles to a parca backend."
                 )
             )
+        else:
+            # by most to least serious issue with the snap, report a blocked status
+            if not self.parca_agent.installed:
+                event.add_status(
+                    ops.BlockedStatus(
+                        "The parca-agent snap is not installed. "
+                        "Check `juju debug-log` for errors during the setup phase."
+                    )
+                )
 
-        # set to blocked if the snap failed to start.
-        # it might happen that the snap would take some time before it becomes "inactive".
-        # if this happens, the charm will be set to blocked in the next processed event.
-        # https://github.com/canonical/parca-agent-operator/issues/56
-        if not self.parca_agent.running:
-            event.add_status(
-                ops.BlockedStatus(
-                    "parca-agent snap is not running. Check `sudo snap logs parca-agent` from inside the juju machine for errors."
+            # set to blocked if the snap failed to start.
+            # it might happen that the snap would take some time before it becomes "inactive".
+            # if this happens, the charm will be set to blocked in the next processed event.
+            # https://github.com/canonical/parca-agent-operator/issues/56
+            elif not self.parca_agent.running:
+                event.add_status(
+                    ops.BlockedStatus(
+                        f"The parca-agent snap is not running. "
+                        f"Check `juju ssh -m {self.model.name} {self.unit.name} sudo snap logs parca-agent` "
+                        f"for errors."
+                    )
                 )
-            )
-        # We'll only hit the below case if the snap is already installed, but failed to refresh.
-        elif self.parca_agent.target_revision != self.parca_agent.revision:
-            event.add_status(
-                ops.BlockedStatus(
-                    "Failed to refresh parca-agent snap. Check `juju debug-log` for errors."
+            # We'll only hit the below case if the snap is already installed,
+            # but couldn't be refreshed during the upgrade-charm event
+            elif (target_revision := self.parca_agent.target_revision) != (current_revision:=self.parca_agent.revision):
+                event.add_status(
+                    ops.BlockedStatus(
+                        f"The parca-agent snap should be at revision {target_revision!r} but is instead at {current_revision!r}. "
+                        "It could be that something went wrong during an upgrade."
+                        "Check `juju debug-log` for errors."
+                    )
                 )
-            )
 
         event.add_status(ops.ActiveStatus(""))
 

--- a/src/parca_agent.py
+++ b/src/parca_agent.py
@@ -46,13 +46,16 @@ class ParcaAgent:
     }
     _confinement = "classic"
 
-    def __init__(self, store_config: Dict[str, str]):
+    def __init__(self, store_config: Optional[Dict[str, str]]):
         self._store_config = store_config
 
     # RECONCILERS
     def reconcile(self):
         """Parca agent reconcile logic."""
-        self._reconcile_config()
+        if self._store_config:
+            self._reconcile_config()
+        else:
+            logger.error("no store configured: cannot reconcile parca_agent")
 
     def _reconcile_config(
         self,
@@ -147,9 +150,9 @@ class ParcaAgent:
 
 def parse_version(vstr: str) -> str:
     """Parse the output of 'parca --version' and return a representative string."""
-    splits = vstr.split(" ")
+    parts = vstr.split(" ")
     # If we're not on a 'proper' released version, include the first few digits of
     # the commit we're build from - e.g. 0.12.1-next+deadbeef
-    if "-next" in splits[2]:
-        return f"{splits[2]}+{splits[4][:6]}"
-    return splits[2]
+    if "-next" in parts[2]:
+        return f"{parts[2]}+{parts[4][:6]}"
+    return parts[2]

--- a/src/parca_agent.py
+++ b/src/parca_agent.py
@@ -6,7 +6,7 @@
 import logging
 import platform
 from subprocess import check_output
-from typing import Dict, Optional, Tuple
+from typing import Dict, Optional, Tuple, cast
 
 from charms.operator_libs_linux.v1 import snap
 
@@ -63,10 +63,13 @@ class ParcaAgent:
         """Configure Parca Agent on the host system.
 
         Restart Parca Agent snap if needed.
+
+        Assumes it only will get called if _store_config is set (i.e. if a remote-store relation is active).
         """
+        store_config = cast(Dict[str, str], self._store_config)
         changes = {}
         for key in ("remote-store-address", "remote-store-insecure", "remote-store-bearer-token"):
-            desired_value = self._store_config.get(key, "")
+            desired_value = store_config.get(key, "")
             current_value = self._snap.get(key)
             if current_value != desired_value:
                 changes[key] = desired_value

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -33,6 +33,7 @@ def parca_charm_noble(build_charms):
     """Parca charm with 24.04 base."""
     return _find_charm(build_charms, "24.04")
 
+
 @fixture(scope="module")
 async def parca_charm_jammy(build_charms):
     """Parca charm with 22.04 base."""

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -30,7 +30,7 @@ async def test_deploy(ops_test: OpsTest, parca_charm_noble, parca_charm_jammy):
     )
 
 
-async def test_agent_running_on_noble_with_virt(ops_test: OpsTest):
+async def test_deploy_on_noble_with_virt(ops_test: OpsTest):
     # Deploy principal on a virtual-machine with ubuntu@24.04 for parca-agent to start.
     # check https://github.com/canonical/parca-agent-operator/issues/37
     # and https://github.com/canonical/parca-agent-operator/issues/47
@@ -46,10 +46,13 @@ async def test_agent_running_on_noble_with_virt(ops_test: OpsTest):
     async with ops_test.fast_forward():
         await asyncio.gather(
             ops_test.model.integrate(UBUNTU_APP_NOBLE, AGENT_NOBLE),
-            # parca-agent will be in active/idle
             ops_test.model.wait_for_idle(
-                apps=[AGENT_NOBLE, UBUNTU_APP_NOBLE], status="active", timeout=500
+                apps=[UBUNTU_APP_NOBLE], status="active", timeout=500
             ),
+            # parca-agent will be in blocked because there's no remote store backend configured
+            ops_test.model.wait_for_idle(
+                apps=[AGENT_NOBLE], status="blocked", timeout=500
+            )
         )
 
 
@@ -57,7 +60,7 @@ async def test_remove_relation_noble(ops_test: OpsTest):
     await ops_test.juju("remove-relation", AGENT_NOBLE, UBUNTU_APP_NOBLE)
 
 
-async def test_agent_blocked_on_jammy_no_virt(ops_test: OpsTest):
+async def test_deploy_on_jammy_no_virt(ops_test: OpsTest):
     await asyncio.gather(
         ops_test.model.deploy(
             UBUNTU,

--- a/tests/unit/test_charm/test_charm.py
+++ b/tests/unit/test_charm/test_charm.py
@@ -20,7 +20,6 @@ from scenario import TCPPort
 def patch_all():
     with ExitStack() as stack:
         stack.enter_context(patch("charm.ParcaAgent.reconcile", lambda _: None))
-        # stack.enter_context(patch("opentelemetry.sdk.trace.export"))
         yield
 
 


### PR DESCRIPTION
Fixes #37 

Update the status management so that the charm will correctly report several high-level failure modes:

- snap not installed: blocked
- if snap installed:
  - snap not running: blocked
  - snap version is not what we'd like it to be: blocked
- active