### PR TITLE
chore: bump parca-agent to latest/stable

### DIFF
--- a/src/parca_agent.py
+++ b/src/parca_agent.py
@@ -46,7 +46,7 @@ class ParcaAgent:
 
     _snap_revisions: Dict[Tuple[str, str], int] = {
         # (confinement, arch): revision
-        ("classic", "amd64"): 2587,  # v0.35.3
+        ("classic", "amd64"): 2619,  # v0.46.0
     }
     _confinement = "classic"
 

--- a/tests/unit/test_charm/test_charm.py
+++ b/tests/unit/test_charm/test_charm.py
@@ -57,7 +57,7 @@ def store_relation():
 @patch("charm.ParcaAgent.refresh", lambda _: True)
 @patch("charm.ParcaAgent.installed", True)
 @patch("charm.ParcaAgent.running", True)
-@patch("charm.ParcaAgent.revision", 2587)
+@patch("charm.ParcaAgent.revision", 2619)
 @patch("charm.ParcaAgent.version", "v0.12.0")
 def test_happy_path_status(context, event, store_relation):
     # GIVEN the charm's install/refresh exit 0
@@ -109,7 +109,7 @@ def test_snap_operation_error_set_blocked(install, refresh, context, event, erro
     assert isinstance(state_out.unit_status, BlockedStatus)
 
 
-@patch("charm.ParcaAgent.revision", 2587)
+@patch("charm.ParcaAgent.revision", 2619)
 @patch("charm.ParcaAgent.version", "v0.12.0")
 @patch("parca_agent.ParcaAgent._snap")
 def test_update_status_refreshes_snap_hold(snap, context):
@@ -119,7 +119,7 @@ def test_update_status_refreshes_snap_hold(snap, context):
 
 
 @patch("charm.ParcaAgent.installed", True)
-@patch("charm.ParcaAgent.revision", 2587)
+@patch("charm.ParcaAgent.revision", 2619)
 @patch("charm.ParcaAgent.version", "v0.12.0")
 @patch("charm.ParcaAgent.start")
 def test_charm_opens_ports_on_start(parca_start, context):
@@ -130,7 +130,7 @@ def test_charm_opens_ports_on_start(parca_start, context):
 
 @patch("charm.ParcaAgent.installed", True)
 @patch("charm.ParcaAgent.running", True)
-@patch("charm.ParcaAgent.revision", 2587)
+@patch("charm.ParcaAgent.revision", 2619)
 @patch("charm.ParcaAgent.version", "v0.12.0")
 @patch("charm.ParcaAgent.start", lambda _: True)
 def test_charm_sets_active_on_start_success(context, store_relation):
@@ -149,7 +149,7 @@ def test_remove(parca_stop, context, store_relation):
 
 @patch("charm.ParcaAgent.installed", True)
 @patch("charm.ParcaAgent.running", True)
-@patch("charm.ParcaAgent.revision", 2587)
+@patch("charm.ParcaAgent.revision", 2619)
 @patch("charm.ParcaAgent.version", "v0.12.0")
 @patch("charm.ParcaAgent.install", lambda _: True)
 @patch("charm.ParcaAgent.refresh", lambda _: True)
@@ -177,7 +177,7 @@ def test_parca_external_store_relation_join(context):
     assert state_out.unit_status == ActiveStatus()
 
 
-@patch("charm.ParcaAgent.revision", 2587)
+@patch("charm.ParcaAgent.revision", 2619)
 @patch("charm.ParcaAgent.version", "v0.12.0")
 @patch("charm.ParcaAgent.installed", True)
 @patch("charm.ParcaAgent.running", True)
@@ -213,7 +213,7 @@ def test_parca_external_store_relation_removed(context, remote_data_present):
 
 @patch("charm.ParcaAgent._snap", MagicMock())
 @patch("subprocess.run", MagicMock())
-@patch("charm.ParcaAgent.revision", 2587)
+@patch("charm.ParcaAgent.revision", 2619)
 @patch("charm.ParcaAgent.version", "v0.12.0")
 @patch("charm.ParcaAgent.installed", True)
 @patch("charm.ParcaAgent.running", True)


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
#114 


## Solution
<!-- A summary of the solution addressing the above issue -->

Quickly pin the parca-agent snap to the latest available in latest/stable (0.46.0). This parca-agent version contains the fix for memory links.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->

N/A

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->

Same as the typical charm installation

## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->

juju refresh to the charm revision that includes this fix after it is released